### PR TITLE
fix defer rollback transaction issues.

### DIFF
--- a/data_test.go
+++ b/data_test.go
@@ -15,13 +15,13 @@
 package apidApigeeSync
 
 import (
+	"github.com/apid/apid-core"
 	"github.com/apid/apid-core/data"
 	"github.com/apigee-labs/transicator/common"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"sort"
 	"strconv"
-	"github.com/apid/apid-core"
 )
 
 var _ = Describe("data access tests", func() {


### PR DESCRIPTION
According to https://blog.golang.org/defer-panic-and-recover
"A deferred function's arguments are evaluated when the defer statement is evaluated."
So the `defer completeTxn(tx, err)` will use the current err value, not the final err value before return. So the err happening after this `defer` will not be used by `completeTxn`. The `completeTxn` will always use nil err, and try to commit the transaction.

The fix is to use `defer tx.Rollback()`. According to https://golang.org/pkg/database/sql/#Tx
"After a call to Commit or Rollback, all operations on the transaction fail with ErrTxDone."
So the deferred `tx.Rollback()` after successful `tx.Commit()` will fail with `ErrTxDone` and cause no problem.